### PR TITLE
Backport AT command interface from LoRa tester firmware

### DIFF
--- a/include/at.h
+++ b/include/at.h
@@ -14,7 +14,18 @@
                          {"$BAND", NULL, at_band_set, at_band_read, NULL, "0:AS923, 1:AU915, 5:EU868, 6:KR920, 7:IN865, 8:US915"},\
                          {"$MODE", NULL, at_mode_set, at_mode_read, NULL, "0:ABP, 1:OTAA"},\
                          {"$NWK", NULL, at_nwk_set, at_nwk_read, NULL, "Network type 0:private, 1:public"},\
-                         {"$JOIN", at_join, NULL, NULL, NULL, "Send OTAA Join packet"}
+                         {"$ADR", NULL, at_adr_set, at_adr_read, NULL, "Automatic data rate 0:disabled, 1:enabled"},\
+                         {"$DR", NULL, at_dr_set, at_dr_read, NULL, "Data rate 0-15"},\
+                         {"$REPU", NULL, at_repu_set, at_repu_read, NULL, "Repeat of unconfirmed transmissions 1-15"},\
+                         {"$REPC", NULL, at_repc_set, at_repc_read, NULL, "Repeat of confirmed transmissions 1-8"},\
+                         {"$JOIN", at_join, NULL, NULL, NULL, "Send OTAA Join packet"},\
+                         {"$FRMCNT", at_frmcnt, NULL, NULL, NULL, "Get frame counters"},\
+                         {"$LNCHECK", at_link_check, NULL, NULL, NULL, "MAC Link Check"},\
+                         {"$RFQ", at_rfq, NULL, NULL, NULL, "Get RSSI/SNR of last RX packet"},\
+                         {"$REBOOT", at_reboot, NULL, NULL, NULL, "Firmware reboot"},\
+                         {"$FRESET", at_freset, NULL, NULL, NULL, "LoRa Module factory reset"},\
+                         {"$FWVER", at_ver_read, NULL, NULL, NULL, "Show LoRa Module firmware version"}
+
 
 #define AT_LED_COMMANDS {"$BLINK", at_blink, NULL, NULL, NULL, "LED blink 3 times"},\
                         {"$LED", NULL, at_led_set, NULL, at_led_help, "LED on/off"}
@@ -47,6 +58,26 @@ bool at_mode_set(twr_atci_param_t *param);
 
 bool at_nwk_read(void);
 bool at_nwk_set(twr_atci_param_t *param);
+
+bool at_adr_read(void);
+bool at_adr_set(twr_atci_param_t *param);
+
+bool at_dr_read(void);
+bool at_dr_set(twr_atci_param_t *param);
+
+bool at_repu_read(void);
+bool at_repu_set(twr_atci_param_t *param);
+
+bool at_repc_read(void);
+bool at_repc_set(twr_atci_param_t *param);
+
+bool at_ver_read(void);
+
+bool at_reboot(void);
+bool at_freset(void);
+bool at_frmcnt(void);
+bool at_link_check(void);
+bool at_rfq(void);
 
 bool at_join(void);
 bool at_blink(void);

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ default_envs = debug
 platform = hardwario-tower
 board = core_module
 framework = stm32cube
-lib_deps = twr-sdk
+lib_deps = https://github.com/hardwario/twr-sdk.git
 monitor_speed = 115200
 monitor_filters = default, send_on_enter
 monitor_flags = --echo
@@ -17,7 +17,7 @@ upload_protocol = serial
 
 [env:release]
 upload_protocol = serial
-build_flags = 
+build_flags =
     ${env.build_flags}
     -D RELEASE
 
@@ -26,6 +26,6 @@ build_type = debug
 upload_protocol = jlink
 debug_init_break = tbreak application_init
 debug_svd_path = .pio/libdeps/debug/twr-sdk/sys/svd/stm32l0x3.svd
-build_flags = 
+build_flags =
     ${env.build_flags}
     -D DEBUG

--- a/src/at.c
+++ b/src/at.c
@@ -1,4 +1,5 @@
-#include <at.h>
+#include "at.h"
+#include <twr.h>
 #include <twr_atci.h>
 
 static struct
@@ -9,8 +10,7 @@ static struct
 
 } _at;
 
-static bool _at_param_eui_test(twr_atci_param_t *param);
-static bool _at_param_key_test(twr_atci_param_t *param);
+static bool _at_param_format_and_test(twr_atci_param_t *param, uint8_t length);
 
 void at_init(twr_led_t *led, twr_cmwx1zzabz_t *lora)
 {
@@ -22,14 +22,14 @@ bool at_deveui_read(void)
 {
     twr_cmwx1zzabz_get_deveui(_at.lora, _at.tmp);
 
-    twr_atci_printf("$DEVEUI: %s", _at.tmp);
+    twr_atci_printfln("$DEVEUI: %s", _at.tmp);
 
     return true;
 }
 
 bool at_deveui_set(twr_atci_param_t *param)
 {
-    if (!_at_param_eui_test(param))
+    if (!_at_param_format_and_test(param, 16))
     {
         return false;
     }
@@ -43,7 +43,7 @@ bool at_devaddr_read(void)
 {
     twr_cmwx1zzabz_get_devaddr(_at.lora, _at.tmp);
 
-    twr_atci_printf("$DEVADDR: %s", _at.tmp);
+    twr_atci_printfln("$DEVADDR: %s", _at.tmp);
 
     return true;
 }
@@ -60,14 +60,14 @@ bool at_nwkskey_read(void)
 {
     twr_cmwx1zzabz_get_nwkskey(_at.lora, _at.tmp);
 
-    twr_atci_printf("$NWKSKEY: %s", _at.tmp);
+    twr_atci_printfln("$NWKSKEY: %s", _at.tmp);
 
     return true;
 }
 
 bool at_nwkskey_set(twr_atci_param_t *param)
 {
-    if (!_at_param_key_test(param))
+    if (!_at_param_format_and_test(param, 32))
     {
         return false;
     }
@@ -81,14 +81,14 @@ bool at_appkey_read(void)
 {
     twr_cmwx1zzabz_get_appkey(_at.lora, _at.tmp);
 
-    twr_atci_printf("$APPKEY: %s", _at.tmp);
+    twr_atci_printfln("$APPKEY: %s", _at.tmp);
 
     return true;
 }
 
 bool at_appkey_set(twr_atci_param_t *param)
 {
-    if (!_at_param_key_test(param))
+    if (!_at_param_format_and_test(param, 32))
     {
         return false;
     }
@@ -102,14 +102,14 @@ bool at_appeui_read(void)
 {
     twr_cmwx1zzabz_get_appeui(_at.lora, _at.tmp);
 
-    twr_atci_printf("$APPEUI: %s", _at.tmp);
+    twr_atci_printfln("$APPEUI: %s", _at.tmp);
 
     return true;
 }
 
 bool at_appeui_set(twr_atci_param_t *param)
 {
-    if (!_at_param_eui_test(param))
+    if (!_at_param_format_and_test(param, 16))
     {
         return false;
     }
@@ -123,14 +123,14 @@ bool at_appskey_read(void)
 {
     twr_cmwx1zzabz_get_appskey(_at.lora, _at.tmp);
 
-    twr_atci_printf("$APPSKEY: %s", _at.tmp);
+    twr_atci_printfln("$APPSKEY: %s", _at.tmp);
 
     return true;
 }
 
 bool at_appskey_set(twr_atci_param_t *param)
 {
-    if (!_at_param_key_test(param))
+    if (!_at_param_format_and_test(param, 32))
     {
         return false;
     }
@@ -144,7 +144,7 @@ bool at_band_read(void)
 {
     twr_cmwx1zzabz_config_band_t band = twr_cmwx1zzabz_get_band(_at.lora);
 
-    twr_atci_printf("$BAND: %d", band);
+    twr_atci_printfln("$BAND: %d", band);
 
     return true;
 }
@@ -167,7 +167,7 @@ bool at_mode_read(void)
 {
     twr_cmwx1zzabz_config_mode_t mode = twr_cmwx1zzabz_get_mode(_at.lora);
 
-    twr_atci_printf("$MODE: %d", mode);
+    twr_atci_printfln("$MODE: %d", mode);
 
     return true;
 }
@@ -193,11 +193,46 @@ bool at_join(void)
     return true;
 }
 
+bool at_frmcnt(void)
+{
+    twr_cmwx1zzabz_frame_counter(_at.lora);
+
+    return true;
+}
+
+bool at_reboot(void)
+{
+    twr_system_reset();
+
+    return true;
+}
+
+bool at_freset(void)
+{
+    twr_cmwx1zzabz_factory_reset(_at.lora);
+
+    return true;
+}
+
+bool at_link_check(void)
+{
+    twr_cmwx1zzabz_link_check(_at.lora);
+
+    return true;
+}
+
+bool at_rfq(void)
+{
+    twr_cmwx1zzabz_rfq(_at.lora);
+
+    return true;
+}
+
 bool at_nwk_read(void)
 {
     uint8_t nwk_public = twr_cmwx1zzabz_get_nwk_public(_at.lora);
 
-    twr_atci_printf("$NWK: %d", nwk_public);
+    twr_atci_printfln("$NWK: %d", nwk_public);
 
     return true;
 }
@@ -212,6 +247,107 @@ bool at_nwk_set(twr_atci_param_t *param)
     }
 
     twr_cmwx1zzabz_set_nwk_public(_at.lora, nwk_public);
+
+    return true;
+}
+
+bool at_adr_read(void)
+{
+    uint8_t adr = twr_cmwx1zzabz_get_adaptive_datarate(_at.lora);
+
+    twr_atci_printfln("$ADR: %d", adr);
+
+    return true;
+}
+
+bool at_adr_set(twr_atci_param_t *param)
+{
+    uint8_t adr = atoi(param->txt);
+
+    if (adr > 1)
+    {
+        return false;
+    }
+
+    twr_cmwx1zzabz_set_adaptive_datarate(_at.lora, adr);
+
+    return true;
+}
+
+bool at_dr_read(void)
+{
+    uint8_t dr = twr_cmwx1zzabz_get_datarate(_at.lora);
+
+    twr_atci_printfln("$DR: %d", dr);
+
+    return true;
+}
+
+bool at_dr_set(twr_atci_param_t *param)
+{
+    uint8_t dr = atoi(param->txt);
+
+    if (dr > 15)
+    {
+        return false;
+    }
+
+    twr_cmwx1zzabz_set_datarate(_at.lora, dr);
+
+    return true;
+}
+
+bool at_repu_read(void)
+{
+    uint8_t repeat = twr_cmwx1zzabz_get_repeat_unconfirmed(_at.lora);
+
+    twr_atci_printfln("$REPU: %d", repeat);
+
+    return true;
+}
+
+bool at_repu_set(twr_atci_param_t *param)
+{
+    uint8_t repeat = atoi(param->txt);
+
+    if (repeat < 1 || repeat > 15)
+    {
+        return false;
+    }
+
+    twr_cmwx1zzabz_set_repeat_unconfirmed(_at.lora, repeat);
+
+    return true;
+}
+
+bool at_repc_read(void)
+{
+    uint8_t repeat = twr_cmwx1zzabz_get_repeat_confirmed(_at.lora);
+
+    twr_atci_printfln("$REPC: %d", repeat);
+
+    return true;
+}
+
+bool at_repc_set(twr_atci_param_t *param)
+{
+    uint8_t repeat = atoi(param->txt);
+
+    if (repeat < 1 || repeat > 8)
+    {
+        return false;
+    }
+
+    twr_cmwx1zzabz_set_repeat_confirmed(_at.lora, repeat);
+
+    return true;
+}
+
+bool at_ver_read(void)
+{
+    const char *version = twr_cmwx1zzabz_get_fw_version(_at.lora);
+
+    twr_atci_printfln("$VER: %s", version);
 
     return true;
 }
@@ -254,37 +390,40 @@ bool at_led_help(void)
     return true;
 }
 
-static bool _at_param_eui_test(twr_atci_param_t *param)
+static bool _at_param_format_and_test(twr_atci_param_t *param, uint8_t length)
 {
-    if (param->length != 16)
-    {
-        return false;
-    }
 
-    for (size_t i = 0; i < param->length; i++)
-    {
-        if (isdigit(param->txt[i]) || isupper(param->txt[i]))
-        {
-            continue;
+    // Capitalize letters
+    for (uint32_t i = 0; param->txt[i] != '\0'; i++) {
+        if (param->txt[i] >= 'a' && param->txt[i] <= 'z') {
+            param->txt[i] = param->txt[i] - 32;
         }
-
-        return false;
     }
 
-    return true;
-}
+    // Skip spaces
+    for (uint32_t i = 0; i < strlen(param->txt); i++)
+    {
+        while (param->txt[i] == ' ')
+        {
+            for (uint32_t q = 0; q < strlen(param->txt); q++)
+            {
+                param->txt[i + q] = param->txt[i + q + 1];
+            }
+        }
+    }
 
+    // Correct new string length
+    param->length = strlen(param->txt);
 
-static bool _at_param_key_test(twr_atci_param_t *param)
-{
-    if (param->length != 32)
+    if (param->length != length)
     {
         return false;
     }
 
-    for (size_t i = 0; i < param->length; i++)
+    // Check the string is HEX
+    for (size_t i = 0; i < strlen(param->txt); i++)
     {
-        if (isdigit(param->txt[i]) || isupper(param->txt[i]))
+        if ((param->txt[i] >= '0' && param->txt[i] <= '9') || (param->txt[i] >= 'A' && param->txt[i] <= 'F'))
         {
             continue;
         }


### PR DESCRIPTION
The LoRa tester firmware has more recent AT command implementation. This pull request switches twr-sdk to the the version from the git repository and backports many of the recent LoRa AT commands from the tester to this firmware.