### PR TITLE
Bake in automatically generated firmware version and build date

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,3 +1,5 @@
+
+
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
@@ -11,18 +13,19 @@ lib_deps = https://github.com/hardwario/twr-sdk.git
 monitor_speed = 115200
 monitor_filters = default, send_on_enter
 monitor_flags = --echo
-build_flags =
-    !echo -D VERSION=\\\"\"$(git describe --abbrev=8 --always --tags --dirty=' (modified)' 2>/dev/null || echo '?')\"\\\"
-    !echo -D BUILD_DATE=\\\"\"$(date +'%%Y-%%m-%%d %%H:%%M:%%S %%Z' 2>/dev/null || echo '?')\"\\\"
 
 [env:debug]
 upload_protocol = serial
+build_flags =
+    ${env.build_flags}
+    !python .pio/libdeps/debug/twr-sdk/git-version.py
 
 [env:release]
 upload_protocol = serial
 build_flags =
     ${env.build_flags}
     -D RELEASE
+    !python .pio/libdeps/release/twr-sdk/git-version.py
 
 [env:debug-jlink]
 build_type = debug
@@ -32,3 +35,4 @@ debug_svd_path = .pio/libdeps/debug/twr-sdk/sys/svd/stm32l0x3.svd
 build_flags =
     ${env.build_flags}
     -D DEBUG
+    !python .pio/libdeps/debug-jlink/twr-sdk/git-version.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,9 @@ lib_deps = https://github.com/hardwario/twr-sdk.git
 monitor_speed = 115200
 monitor_filters = default, send_on_enter
 monitor_flags = --echo
+build_flags =
+    !echo -D VERSION=\\\"\"$(git describe --abbrev=8 --always --tags --dirty=' (modified)' 2>/dev/null || echo '?')\"\\\"
+    !echo -D BUILD_DATE=\\\"\"$(date +'%%Y-%%m-%%d %%H:%%M:%%S %%Z' 2>/dev/null || echo '?')\"\\\"
 
 [env:debug]
 upload_protocol = serial

--- a/src/application.c
+++ b/src/application.c
@@ -319,10 +319,10 @@ bool at_status(void)
     return true;
 }
 
-#if defined(VERSION) && defined(BUILD_DATE)
+#if defined(GIT_VERSION) && defined(BUILD_DATE)
 static bool at_version()
 {
-    twr_atci_printfln("$VER: %s built on %s", VERSION, BUILD_DATE);
+    twr_atci_printfln("$VER: %s built on %s", GIT_VERSION, BUILD_DATE);
     return true;
 }
 #endif
@@ -388,7 +388,7 @@ void application_init(void)
             {"$SEND", at_send, NULL, NULL, NULL, "Immediately send packet"},
             {"$CALIBRATION", at_calibration, NULL, NULL, NULL, "Immediately send packet"},
             {"$STATUS", at_status, NULL, NULL, NULL, "Show status"},
-            #if defined(VERSION) && defined(BUILD_DATE)
+            #if defined(GIT_VERSION) && defined(BUILD_DATE)
             {"$VER", at_version, NULL, NULL, NULL, "Show firmware version and build date"},
             #endif
             AT_LED_COMMANDS,

--- a/src/application.c
+++ b/src/application.c
@@ -319,6 +319,14 @@ bool at_status(void)
     return true;
 }
 
+#if defined(VERSION) && defined(BUILD_DATE)
+static bool at_version()
+{
+    twr_atci_printfln("$VER: %s built on %s", VERSION, BUILD_DATE);
+    return true;
+}
+#endif
+
 void application_init(void)
 {
     twr_data_stream_init(&sm_voltage, 1, &sm_voltage_buffer);
@@ -380,6 +388,9 @@ void application_init(void)
             {"$SEND", at_send, NULL, NULL, NULL, "Immediately send packet"},
             {"$CALIBRATION", at_calibration, NULL, NULL, NULL, "Immediately send packet"},
             {"$STATUS", at_status, NULL, NULL, NULL, "Show status"},
+            #if defined(VERSION) && defined(BUILD_DATE)
+            {"$VER", at_version, NULL, NULL, NULL, "Show firmware version and build date"},
+            #endif
             AT_LED_COMMANDS,
             TWR_ATCI_COMMAND_CLAC,
             TWR_ATCI_COMMAND_HELP


### PR DESCRIPTION
I often forget which firmware version is loaded in my devices. As a consequence, I have to flash often if I want to make sure the devices are up-to-date. This is particularly annoying during development.

I would like to propose to include an automatically generated firmware version and build date in the firmware and make that information available via a new AT command called `AT$VER`. The version string is generated using `git`. The build date string is generated using `date`. If either program is missing on the build host, the corresponding string will be set to just '?'. The two strings are injected into the firmware via two new preprocessor macros: `VERSION` and `BUILD_DATE`.

The new AT command `AT$VER` outputs the following string:
```txt
AT$VER
$VER: v1.1.1-2-gfa610fde (modified) built on 2021-12-18 12:49:52 CET
OK
```
The anatomy of the version string is as follows. `v1.1.1` is the most recent tag in the git repository. `-2` represents the number of commits on top of the tag. `-gfa610fde` represents the git commit ID of the most recent commit (usually HEAD). String `(modified)` is only present if the git clone the firmware was generated from contained local (uncommitted) modifications.

The version string format is designed to allow alphabetical version comparison. Thus, to determine if one version is more recent than another, one can simply compare the version string components before the first whitespace delimiter (assuming the tag has no spaces in it). The sorting algorithm obviously only works if the tag name contains a real version number, i.e., something like "1.2.3".

If you choose to adopt this feature and implement it across Hardwario firmwares, it might be eventually possible to automatically detect (e.g., in Hardwario Playground) whether any of the connected devices need to have firmware upgraded. That would be a useful improvement, I think.